### PR TITLE
fixing the timestamp format

### DIFF
--- a/gstv-initiated-messages/configuration-network/configuration-network.md
+++ b/gstv-initiated-messages/configuration-network/configuration-network.md
@@ -24,7 +24,7 @@ Message sent with the network wide configuration values including shutdown hours
     - MEDIA_CHECK
     - CONFIGURATION_PULLED_BY_TERMINAL
     - CONFIGURATION_ACCEPTED_BY_TERMINAL
-- **notificationTimestamp** - A UTC date and time that indicates when this update was created. This can be used to ensure updates are applied in the appropriate order. The format will be `year-month-day hours:mins:secs:milliseconds` using 24 hour time.
+- **notificationTimestamp** - A UTC date and time that indicates when this update was created. This can be used to ensure updates are applied in the appropriate order. The format will be `year-month-day hours:mins:secs.milliseconds` using 24 hour time.
 - **status** - A String that will indicate if the step in the update process for which this notification was generated succeeded or failed.
   - Values
     - success


### PR DESCRIPTION
fixing the timestamp format to use a dot between seconds and milliseconds